### PR TITLE
feat: implement `wrapweight all` command

### DIFF
--- a/command-work/main.sh
+++ b/command-work/main.sh
@@ -55,6 +55,9 @@ function commandWork {
         "init" | "start" | "stop" | "kill")
             forOther
             ;;
+        "wrapweight")
+            forWrapweight
+            ;;
         *)
             throwError 113 "Tried command: $command"
             ;;
@@ -63,6 +66,32 @@ function commandWork {
     
 
     exit 0
+}
+
+function forWrapweight {
+    local file_to_source
+    local exit_code
+    local subcommand
+
+    if [[ ${#command_as_args[@]} -lt 2 ]]; then
+        throwError 120 "Length is less than 2"
+    fi
+
+    subcommand="${command_as_args[1]}"
+
+    if [[ "$subcommand" == "all" ]]; then
+        file_to_source="$current_dir/wrapweight/main.sh"
+        source "$file_to_source"
+        [ $? -ne 0 ] && throwError 111 "$file_to_source"
+
+        (
+            wrapWeightAll "$scripts_dir" "$file_with_config" "$unique_prefix"
+        )
+        exit_code=$?
+        [ $exit_code -ne 0 ] && throwError 117 "Exit code was: $exit_code"
+    else
+        throwError 121 "Mentioned: $subcommand"
+    fi
 }
 
 function forGet {

--- a/command-work/main.sh
+++ b/command-work/main.sh
@@ -88,9 +88,9 @@ function forWrapweight {
             wrapWeightAll "$scripts_dir" "$file_with_config" "$unique_prefix"
         )
         exit_code=$?
-        [ $exit_code -ne 0 ] && throwError 117 "Exit code was: $exit_code"
+        [ $exit_code -ne 0 ] && throwError 128 "Exit code was: $exit_code"
     else
-        throwError 121 "Mentioned: $subcommand"
+        throwError 129 "Mentioned: $subcommand"
     fi
 }
 

--- a/command-work/utils.sh
+++ b/command-work/utils.sh
@@ -61,6 +61,12 @@ function throwError {
         127)
             echo "Failed to remove temporary file" >&2
             ;;
+        128)
+            echo "Problem with wrapweight command" >&2
+            ;;
+        129)
+            echo "Unknown wrapweight subcommand" >&2
+            ;;
         *)
             echo "Unknown error" >&2
             exit 1

--- a/command-work/wrapweight/main.sh
+++ b/command-work/wrapweight/main.sh
@@ -79,25 +79,29 @@ function calcWeight {
 
         getSequence "$scripts_dir" "$file_with_config" "$unique_prefix" "$wrap_name"
     )
+    [ $? -ne 0 ] && throwError 114 "$sequence"
 
-    if [ $? -eq 0 ]; then
-        sequence_length=$(echo "$sequence" | jq -r "length")
-        if [ $? -eq 0 ]; then
-            for (( j=0; j<sequence_length; j++ )); do
-                seq_item=$(echo "$sequence" | jq -r ".[$j]")
+    sequence_length=$(echo "$sequence" | jq -r "length")
+    [ $? -ne 0 ] && throwError 1 "Error: $sequence_length"
 
-                # Use jq to get the name directly to avoid needing to source extra scripts or if they are already sourced
-                seq_wrap_name=$(echo "$seq_item" | jq -r ".name")
+    for (( j=0; j<sequence_length; j++ )); do
+        seq_item=$(echo "$sequence" | jq -r ".[$j]")
+        [ $? -ne 0 ] && throwError 1 "Error: $seq_item"
 
-                if [[ -n "$seq_wrap_name" && "$seq_wrap_name" != "null" ]]; then
-                    is_in_config=$(echo "$all_wrap_names" | jq -r --arg name "$seq_wrap_name" 'any(. == $name)')
-                    if [[ "$is_in_config" == "true" ]]; then
-                        current_weights=$(echo "$current_weights" | jq -r --arg name "$seq_wrap_name" '.[$name] = (.[$name] + 1)')
-                    fi
-                fi
-            done
+        # Use jq to get the name directly to avoid needing to source extra scripts or if they are already sourced
+        seq_wrap_name=$(echo "$seq_item" | jq -r ".name")
+        [ $? -ne 0 ] && throwError 1 "Error: $seq_wrap_name"
+
+        if [[ -n "$seq_wrap_name" && "$seq_wrap_name" != "null" ]]; then
+            is_in_config=$(echo "$all_wrap_names" | jq -r --arg name "$seq_wrap_name" 'any(. == $name)')
+            [ $? -ne 0 ] && throwError 1 "Error: $is_in_config"
+
+            if [[ "$is_in_config" == "true" ]]; then
+                current_weights=$(echo "$current_weights" | jq -r --arg name "$seq_wrap_name" '.[$name] = (.[$name] + 1)')
+                [ $? -ne 0 ] && throwError 1 "Error: $current_weights"
+            fi
         fi
-    fi
+    done
 
     echo "$current_weights"
 }

--- a/command-work/wrapweight/main.sh
+++ b/command-work/wrapweight/main.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+function wrapWeightAll {
+    local scripts_dir="$1"
+    local file_with_config="$2"
+    local unique_prefix="$3"
+
+    local file_to_source
+    local wrap_names
+    local wrap_names_length
+    local i
+    local wrap_name
+    local weights="{}"
+
+    file_to_source="$scripts_dir/config-file-work/get-all-wrap-names.sh"
+    source "$file_to_source"
+    [ $? -ne 0 ] && throwError 111 "$file_to_source"
+
+    wrap_names=$(getAllWrapNames "$file_with_config")
+    [ $? -ne 0 ] && throwError 123 "$wrap_names"
+
+    wrap_names_length=$(echo "$wrap_names" | jq -r "length")
+    [ $? -ne 0 ] && throwError 1 "Error: $wrap_names_length"
+
+    # initialize weights with 0 for all wraps in config
+    for (( i=0; i<wrap_names_length; i++ )); do
+        wrap_name=$(echo "$wrap_names" | jq -r ".[$i]")
+        [ $? -ne 0 ] && throwError 1 "Error: $wrap_name"
+
+        if [[ -n "$wrap_name" && "$wrap_name" != "null" ]]; then
+            weights=$(echo "$weights" | jq -r --arg name "$wrap_name" '.[$name] = 0')
+        fi
+    done
+
+    # calculate weights
+    for (( i=0; i<wrap_names_length; i++ )); do
+        wrap_name=$(echo "$wrap_names" | jq -r ".[$i]")
+        [ $? -ne 0 ] && throwError 1 "Error: $wrap_name"
+
+        if [[ -n "$wrap_name" && "$wrap_name" != "null" ]]; then
+            weights=$(calcWeight "$scripts_dir" "$file_with_config" "$unique_prefix" "$wrap_name" "$weights" "$wrap_names")
+            [ $? -ne 0 ] && throwError 124 "$weights"
+        fi
+    done
+
+    # Print nicely
+    echo "$weights" | jq .
+
+    exit 0
+}
+
+function calcWeight {
+    local scripts_dir="$1"
+    local file_with_config="$2"
+    local unique_prefix="$3"
+    local wrap_name="$4"
+    local current_weights="$5"
+    local all_wrap_names="$6"
+
+    local sequence
+    local sequence_length
+    local j
+    local seq_item
+    local seq_wrap_name
+    local is_in_config
+
+    # Add +1 to the current wrap
+    current_weights=$(echo "$current_weights" | jq -r --arg name "$wrap_name" '.[$name] = (.[$name] + 1)')
+
+    # Execute getSequence in a subshell since it exits
+    sequence=$(
+        source "$scripts_dir/utils.sh"
+        source "$scripts_dir/install-all-necessary/main.sh"
+        source "$scripts_dir/command-work/utils.sh"
+        source "$scripts_dir/command-work/get-sequence/main.sh"
+
+        getSequence "$scripts_dir" "$file_with_config" "$unique_prefix" "$wrap_name"
+    )
+
+    if [ $? -eq 0 ]; then
+        sequence_length=$(echo "$sequence" | jq -r "length")
+        if [ $? -eq 0 ]; then
+            for (( j=0; j<sequence_length; j++ )); do
+                seq_item=$(echo "$sequence" | jq -r ".[$j]")
+
+                # Use jq to get the name directly to avoid needing to source extra scripts or if they are already sourced
+                seq_wrap_name=$(echo "$seq_item" | jq -r ".name")
+
+                if [[ -n "$seq_wrap_name" && "$seq_wrap_name" != "null" ]]; then
+                    is_in_config=$(echo "$all_wrap_names" | jq -r --arg name "$seq_wrap_name" 'any(. == $name)')
+                    if [[ "$is_in_config" == "true" ]]; then
+                        current_weights=$(echo "$current_weights" | jq -r --arg name "$seq_wrap_name" '.[$name] = (.[$name] + 1)')
+                    fi
+                fi
+            done
+        fi
+    fi
+
+    echo "$current_weights"
+}

--- a/command-work/wrapweight/main.sh
+++ b/command-work/wrapweight/main.sh
@@ -5,7 +5,10 @@ function wrapWeightAll {
     local file_with_config="$2"
     local unique_prefix="$3"
 
-    local file_to_source
+    local file_to_source="$scripts_dir/command-work/wrapweight/utils.sh"
+    source "$file_to_source"
+    [ $? -ne 0 ] && exit 111
+
     local wrap_names
     local wrap_names_length
     local i

--- a/command-work/wrapweight/utils.sh
+++ b/command-work/wrapweight/utils.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function throwError {
+    local error_code="$1"
+    local more_about_error="$2"
+    if [ ! -z "$more_about_error" ]; then
+        echo "$more_about_error" | while IFS= read -r line; do
+            echo "$line" >&2
+        done
+    fi
+
+    case $error_code in
+        1)
+            echo "<- Error within jq command" >&2
+            ;;
+        111)
+            echo "<- Problem with sourcing" >&2
+            ;;
+        123)
+            echo "<- Problem within getAllWrapNames function" >&2
+            ;;
+        124)
+            echo "<- Problem within calcWeight function" >&2
+            ;;
+        *)
+            echo "Unknown error" >&2
+            exit 1
+            ;;
+    esac
+
+    exit $error_code
+}


### PR DESCRIPTION
Implements the `wrapweight all` command per the diagram provided. It counts weights by +1 for the wrap itself and +1 for any valid config wrap in its dependency sequence, outputting a valid JSON dictionary.

---
*PR created automatically by Jules for task [15483338615588599345](https://jules.google.com/task/15483338615588599345) started by @RomaTk*