### PR TITLE
Fix performance bottlenecks with repeated jq calls in loops

### DIFF
--- a/command-work/get-sequence/main.sh
+++ b/command-work/get-sequence/main.sh
@@ -113,9 +113,8 @@ function goThrewSequence {
         new_sequence="[]"
 
         # Read JSON array elements into bash array
-        local items_array
-    eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
-    [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
+        eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
+        [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
         for item in "${items_array[@]}"; do
             is_precreate="$(getIsPrecreate "$item")"
@@ -168,8 +167,7 @@ function changeNewItemsAsAbstractOnly {
     local is_precreate
     local new_items="[]"
     local items_array
-
-    local items_array
+    local new_sequence
     eval "items_array=($(echo "$items" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
     [ $? -ne 0 ] && throwError 1 "Error parsing items"
 
@@ -186,8 +184,8 @@ function changeNewItemsAsAbstractOnly {
         fi
 
         new_sequence="$(jq -c -r --argjson seq "$new_items" --argjson it "$item" '$seq + [$it]' <<<"{}")"
+        [ $? -ne 0 ] && throwError 1 "Error: $new_sequence"
         new_items="$new_sequence"
-        [ $? -ne 0 ] && throwError 1 "Error: $new_items"
     done
 
     echo "$new_items"
@@ -206,8 +204,6 @@ function isInSequenceAlready {
 
     item_to_check_name="$(getBasedOnName "$item_to_check")"
     [ $? -ne 0 ] && throwError 117 "$item_to_check_name"
-
-    local items_array
     eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
     [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
@@ -237,8 +233,6 @@ function sortSequence {
     local is_in_sequence_already
     local items_array
     local new_sequence
-
-    local items_array
     eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
     [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
@@ -253,6 +247,7 @@ function sortSequence {
         [ $? -ne 0 ] && throwError 118 "$tag"
 
         if [[ "$is_precreate" == "false" && "$is_as_abstract" != "true" ]] || [[ "$tag" != "latest" ]]; then
+            # Only one non-precreate or non-latest item is allowed in the sequence and it should be the first one
             sorted_sequence_length=$(echo "$sorted_sequence" | jq -r "length")
             [ $? -ne 0 ] && throwError 1 "$sorted_sequence_length"
             if [[ "$sorted_sequence_length" -eq 0 ]]; then
@@ -269,8 +264,8 @@ function sortSequence {
         fi
 
         new_sequence="$(jq -c -r --argjson seq "$sorted_sequence" --argjson it "$item" '$seq + [$it]' <<<"{}")"
+        [ $? -ne 0 ] && throwError 1 "Error: $new_sequence"
         sorted_sequence="$new_sequence"
-        [ $? -ne 0 ] && throwError 1 "Error: $sorted_sequence"
     done
 
     echo "$sorted_sequence"
@@ -285,8 +280,6 @@ function removeIsAnalysed {
     local new_sequence="[]"
     local items_array
     local next_sequence
-
-    local items_array
     eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
     [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
@@ -295,8 +288,8 @@ function removeIsAnalysed {
         [ $? -ne 0 ] && throwError 1 "Error: $item"
 
         next_sequence="$(jq -c -r --argjson seq "$new_sequence" --argjson it "$item" '$seq + [$it]' <<<"{}")"
+        [ $? -ne 0 ] && throwError 1 "Error: $next_sequence"
         new_sequence="$next_sequence"
-        [ $? -ne 0 ] && throwError 1 "Error: $new_sequence"
     done
 
     echo "$new_sequence"

--- a/command-work/get-sequence/main.sh
+++ b/command-work/get-sequence/main.sh
@@ -97,40 +97,34 @@ function getItemsForSequence {
 function goThrewSequence {
     local sequence="$1"
 
-    local length
     local item
     local is_precreate
     local is_as_abstract
     local is_analysed
     local name
-    local i
     local new_items
-    local items_length
-
     local new_sequence
 
     local changeMade="true"
+    local items_array
 
     while [[ "$changeMade" == "true" ]]; do
         changeMade="false"
-
         new_sequence="[]"
 
-        length=$(echo "$sequence" | jq -r "length")
-        [ $? -ne 0 ] && throwError 1 "Error: $length"
+        # Read JSON array elements into bash array
+        local items_array
+    eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
+    [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
-        for (( i=0; i<length; i++ )); do
-
-            item=$(echo "$sequence" | jq -r ".[$i]")
-            [ $? -ne 0 ] && throwError 1 "Error: $item"
-
+        for item in "${items_array[@]}"; do
             is_precreate="$(getIsPrecreate "$item")"
             [ $? -ne 0 ] && throwError 116 "$is_precreate"
 
             is_as_abstract="$(getAsAbstract "$item")"
             [ $? -ne 0 ] && throwError 123 "$is_as_abstract"
 
-            is_analysed="$(echo "$item" | jq -r ".isAnalysed")"
+            is_analysed="$(echo "$item" | jq -r '.isAnalysed')"
             [ $? -ne 0 ] && throwError 1 "Error: $is_analysed"
 
             if [[ "$is_precreate" == "true" || "$is_as_abstract" == "true" ]] && [[ "$is_analysed" != "true" ]]; then
@@ -146,46 +140,40 @@ function goThrewSequence {
                     [ $? -ne 0 ] && throwError 124 "$new_items"
                 fi
 
-                item=$(echo "$item" | jq -r ".isAnalysed=true")
+                item=$(echo "$item" | jq -c -r '.isAnalysed=true')
                 [ $? -ne 0 ] && throwError 1 "Error: $item"
 
-                new_sequence=$(echo "$new_sequence" | jq -r ". + $new_items + [$item]")
+                new_sequence=$(jq -c -r --argjson seq "$new_sequence" --argjson ni "$new_items" --argjson it "$item" '$seq + $ni + [$it]' <<<"{}")
                 [ $? -ne 0 ] && throwError 1 "Error: $new_sequence"
 
                 changeMade="true"
             else
-                new_sequence=$(echo "$new_sequence" | jq -r ". + [$item]")
+                new_sequence=$(jq -c -r --argjson seq "$new_sequence" --argjson it "$item" '$seq + [$it]' <<<"{}")
                 [ $? -ne 0 ] && throwError 1 "Error: $new_sequence"
             fi
-
         done
 
         sequence="$new_sequence"        
-        
     done
 
     echo "$sequence"
-
     exit 0
 }
 
 function changeNewItemsAsAbstractOnly {
     local items="$1"
 
-    local length
     local item
     local is_as_abstract
     local is_precreate
-    local i
     local new_items="[]"
+    local items_array
 
-    length=$(echo "$items" | jq -r "length")
-    [ $? -ne 0 ] && throwError 1 "Error: $length"
+    local items_array
+    eval "items_array=($(echo "$items" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
+    [ $? -ne 0 ] && throwError 1 "Error parsing items"
 
-    for (( i=0; i<length; i++ )); do
-        item=$(echo "$items" | jq -r ".[$i]")
-        [ $? -ne 0 ] && throwError 1 "Error: $item"
-
+    for item in "${items_array[@]}"; do
         is_precreate="$(getIsPrecreate "$item")"
         [ $? -ne 0 ] && throwError 116 "$is_precreate"
 
@@ -193,11 +181,12 @@ function changeNewItemsAsAbstractOnly {
         [ $? -ne 0 ] && throwError 123 "$is_as_abstract"
 
         if [[ "$is_precreate" == "true" || "$is_as_abstract" == "true" ]]; then
-            item="$(echo "$item" | jq -r ".asAbstract=true | .precreate=false")"
+            item="$(echo "$item" | jq -c -r '.asAbstract=true | .precreate=false')"
             [ $? -ne 0 ] && throwError 1 "Error: $item"
         fi
 
-        new_items="$(echo "$new_items" | jq -r ". + [$item]")"
+        new_sequence="$(jq -c -r --argjson seq "$new_items" --argjson it "$item" '$seq + [$it]' <<<"{}")"
+        new_items="$new_sequence"
         [ $? -ne 0 ] && throwError 1 "Error: $new_items"
     done
 
@@ -210,22 +199,19 @@ function isInSequenceAlready {
     local sequence="$1"
     local item_to_check="$2"
 
-    local length
     local item
     local name
     local item_to_check_name
-    local i
-
-    length=$(echo "$sequence" | jq -r "length")
-    [ $? -ne 0 ] && throwError 1 "Error: $length"
+    local items_array
 
     item_to_check_name="$(getBasedOnName "$item_to_check")"
     [ $? -ne 0 ] && throwError 117 "$item_to_check_name"
 
-    for (( i=0; i<length; i++ )); do
-        item=$(echo "$sequence" | jq -r ".[$i]")
-        [ $? -ne 0 ] && throwError 1 "Error: $item"
+    local items_array
+    eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
+    [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
+    for item in "${items_array[@]}"; do
         name="$(getBasedOnName "$item")"
         [ $? -ne 0 ] && throwError 117 "$name"
 
@@ -242,24 +228,21 @@ function isInSequenceAlready {
 function sortSequence {
     local sequence="$1"
 
-    local length
     local sorted_sequence="[]"
     local sorted_sequence_length
     local item
     local is_precreate
     local is_as_abstract
-    local initial_item
     local tag
-    local i
     local is_in_sequence_already
+    local items_array
+    local new_sequence
 
-    length=$(echo "$sequence" | jq -r "length")
-    [ $? -ne 0 ] && throwError 1 "Error: $length"
+    local items_array
+    eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
+    [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
-    for (( i=0; i<length; i++ )); do
-        item=$(echo "$sequence" | jq -r ".[$i]")
-        [ $? -ne 0 ] && throwError 1 "Error: $item"
-
+    for item in "${items_array[@]}"; do
         is_precreate="$(getIsPrecreate "$item")"
         [ $? -ne 0 ] && throwError 116 "$is_precreate"
 
@@ -269,16 +252,12 @@ function sortSequence {
         tag="$(getBasedOnTag "$item")"
         [ $? -ne 0 ] && throwError 118 "$tag"
 
-        initial_item="$item"
-
         if [[ "$is_precreate" == "false" && "$is_as_abstract" != "true" ]] || [[ "$tag" != "latest" ]]; then
-            # Only one non-precreate or non-latest item is allowed in the sequence and it should be the first one
             sorted_sequence_length=$(echo "$sorted_sequence" | jq -r "length")
             [ $? -ne 0 ] && throwError 1 "$sorted_sequence_length"
             if [[ "$sorted_sequence_length" -eq 0 ]]; then
                 sorted_sequence="[$item]"
             fi
-        
             continue
         fi
 
@@ -289,9 +268,9 @@ function sortSequence {
             continue
         fi
 
-        sorted_sequence="$(echo "$sorted_sequence" | jq -r ". + [$item]")"
+        new_sequence="$(jq -c -r --argjson seq "$sorted_sequence" --argjson it "$item" '$seq + [$it]' <<<"{}")"
+        sorted_sequence="$new_sequence"
         [ $? -ne 0 ] && throwError 1 "Error: $sorted_sequence"
-
     done
 
     echo "$sorted_sequence"
@@ -302,19 +281,21 @@ function sortSequence {
 function removeIsAnalysed {
     local sequence="$1"
 
-    local length
     local item
-    local i
     local new_sequence="[]"
+    local items_array
+    local next_sequence
 
-    length=$(echo "$sequence" | jq -r "length")
-    [ $? -ne 0 ] && throwError 1 "Error: $length"
+    local items_array
+    eval "items_array=($(echo "$sequence" | jq -e -r '.[] | (if type == "string" then . else tostring end) | @sh'))"
+    [ $? -ne 0 ] && throwError 1 "Error parsing sequence"
 
-    for (( i=0; i<length; i++ )); do
-        item=$(echo "$sequence" | jq -r ".[$i] | del(.isAnalysed)")
+    for item in "${items_array[@]}"; do
+        item=$(echo "$item" | jq -c -r 'del(.isAnalysed)')
         [ $? -ne 0 ] && throwError 1 "Error: $item"
 
-        new_sequence="$(echo "$new_sequence" | jq -r ". + [$item]")"
+        next_sequence="$(jq -c -r --argjson seq "$new_sequence" --argjson it "$item" '$seq + [$it]' <<<"{}")"
+        new_sequence="$next_sequence"
         [ $? -ne 0 ] && throwError 1 "Error: $new_sequence"
     done
 

--- a/command-work/init/data-get/run-after-build.sh
+++ b/command-work/init/data-get/run-after-build.sh
@@ -127,7 +127,7 @@ function getRunAfterBuild {
         all_run_before_builds=$(getImplementSpecificData "${based_ons[$i]}" "$all_run_before_builds" "$file_with_config" "$config_dir" "run-after-build")
         [ $? -ne 0 ] && throwError 149 "$all_run_before_builds"
 
-        based_on_jq_array=$(echo "$based_on_jq_array" | jq -r ". + [\"${based_ons[$i]}\"]")
+        based_on_jq_array=$(jq -c -r --argjson arr "$based_on_jq_array" --arg val "${based_ons[$i]}" '$arr + [$val]' <<<"{}")
         [ $? -ne 0 ] && throwError 152 "$based_on_jq_array"
     done
 
@@ -138,17 +138,17 @@ function getRunAfterBuild {
 
         if [[ "$as_abstract" == "true" ]]; then
 
-            abstract_jq_array_commands_some_wrap=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\"")
+            abstract_jq_array_commands_some_wrap=$(jq -c -r --arg key "$wrap_name" '.[$key]' <<<"$all_run_before_builds")
             [ $? -ne 0 ] && throwError 1
             if [[ "$abstract_jq_array_commands_some_wrap" != "null" ]]; then
-                abstract_jq_array_commands=$(echo "$abstract_jq_array_commands" | jq -r ". + $abstract_jq_array_commands_some_wrap")
+                abstract_jq_array_commands=$(jq -c -r --argjson arr "$abstract_jq_array_commands" --argjson ext "$abstract_jq_array_commands_some_wrap" '$arr + $ext' <<<"{}")
                 [ $? -ne 0 ] && throwError 1
             fi
 
-            all_run_before_builds=$(echo "$all_run_before_builds" | jq -r "del(.\"$wrap_name\")")
+            all_run_before_builds=$(jq -c -r --arg key "$wrap_name" 'del(.[$key])' <<<"$all_run_before_builds")
             [ $? -ne 0 ] && throwError 1
 
-            based_on_jq_array=$(echo "$based_on_jq_array" | jq -r ". - [\"$wrap_name\"]")
+            based_on_jq_array=$(jq -c -r --argjson arr "$based_on_jq_array" --arg val "$wrap_name" '$arr - [$val]' <<<"{}")
             [ $? -ne 0 ] && throwError 1
 
             continue
@@ -158,17 +158,17 @@ function getRunAfterBuild {
             continue
         fi
 
-        current_object=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\"")
+        current_object=$(jq -c -r --arg key "$wrap_name" '.[$key]' <<<"$all_run_before_builds")
         [ $? -ne 0 ] && throwError 1
 
         if [[ "$current_object" == "null" ]]; then
-            all_run_before_builds=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\" = $abstract_jq_array_commands")
+            all_run_before_builds=$(jq -c -r --argjson obj "$all_run_before_builds" --arg key "$wrap_name" --argjson val "$abstract_jq_array_commands" '$obj | .[$key] = $val' <<<"{}")
             [ $? -ne 0 ] && throwError 1
         else
-            current_object=$(echo "$current_object" | jq -r "$abstract_jq_array_commands + .")
+            current_object=$(jq -c -r --argjson arr1 "$abstract_jq_array_commands" --argjson arr2 "$current_object" '$arr1 + $arr2' <<<"{}")
             [ $? -ne 0 ] && throwError 1
 
-            all_run_before_builds=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\" = $current_object")
+            all_run_before_builds=$(jq -c -r --argjson obj "$all_run_before_builds" --arg key "$wrap_name" --argjson val "$current_object" '$obj | .[$key] = $val' <<<"{}")
             [ $? -ne 0 ] && throwError 1
         fi
 

--- a/command-work/init/data-get/run-before-build.sh
+++ b/command-work/init/data-get/run-before-build.sh
@@ -127,7 +127,7 @@ function getRunBeforeBuild {
         all_run_before_builds=$(getImplementSpecificData "${based_ons[$i]}" "$all_run_before_builds" "$file_with_config" "$config_dir" "run-before-build")
         [ $? -ne 0 ] && throwError 149 "$all_run_before_builds"
 
-        based_on_jq_array=$(echo "$based_on_jq_array" | jq -r ". + [\"${based_ons[$i]}\"]")
+        based_on_jq_array=$(jq -c -r --argjson arr "$based_on_jq_array" --arg val "${based_ons[$i]}" '$arr + [$val]' <<<"{}")
         [ $? -ne 0 ] && throwError 152 "$based_on_jq_array"
 
     done
@@ -139,17 +139,17 @@ function getRunBeforeBuild {
 
         if [[ "$as_abstract" == "true" ]]; then
 
-            abstract_jq_array_commands_some_wrap=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\"")
+            abstract_jq_array_commands_some_wrap=$(jq -c -r --arg key "$wrap_name" '.[$key]' <<<"$all_run_before_builds")
             [ $? -ne 0 ] && throwError 1
             if [[ "$abstract_jq_array_commands_some_wrap" != "null" ]]; then
-                abstract_jq_array_commands=$(echo "$abstract_jq_array_commands" | jq -r ". + $abstract_jq_array_commands_some_wrap")
+                abstract_jq_array_commands=$(jq -c -r --argjson arr "$abstract_jq_array_commands" --argjson ext "$abstract_jq_array_commands_some_wrap" '$arr + $ext' <<<"{}")
                 [ $? -ne 0 ] && throwError 1
             fi
 
-            all_run_before_builds=$(echo "$all_run_before_builds" | jq -r "del(.\"$wrap_name\")")
+            all_run_before_builds=$(jq -c -r --arg key "$wrap_name" 'del(.[$key])' <<<"$all_run_before_builds")
             [ $? -ne 0 ] && throwError 1
 
-            based_on_jq_array=$(echo "$based_on_jq_array" | jq -r ". - [\"$wrap_name\"]")
+            based_on_jq_array=$(jq -c -r --argjson arr "$based_on_jq_array" --arg val "$wrap_name" '$arr - [$val]' <<<"{}")
             [ $? -ne 0 ] && throwError 1
 
             continue
@@ -159,17 +159,17 @@ function getRunBeforeBuild {
             continue
         fi
 
-        current_object=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\"")
+        current_object=$(jq -c -r --arg key "$wrap_name" '.[$key]' <<<"$all_run_before_builds")
         [ $? -ne 0 ] && throwError 1
 
         if [[ "$current_object" == "null" ]]; then
-            all_run_before_builds=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\" = $abstract_jq_array_commands")
+            all_run_before_builds=$(jq -c -r --argjson obj "$all_run_before_builds" --arg key "$wrap_name" --argjson val "$abstract_jq_array_commands" '$obj | .[$key] = $val' <<<"{}")
             [ $? -ne 0 ] && throwError 1
         else
-            current_object=$(echo "$current_object" | jq -r "$abstract_jq_array_commands + .")
+            current_object=$(jq -c -r --argjson arr1 "$abstract_jq_array_commands" --argjson arr2 "$current_object" '$arr1 + $arr2' <<<"{}")
             [ $? -ne 0 ] && throwError 1
 
-            all_run_before_builds=$(echo "$all_run_before_builds" | jq -r ".\"$wrap_name\" = $current_object")
+            all_run_before_builds=$(jq -c -r --argjson obj "$all_run_before_builds" --arg key "$wrap_name" --argjson val "$current_object" '$obj | .[$key] = $val' <<<"{}")
             [ $? -ne 0 ] && throwError 1
         fi
 

--- a/command-work/init/run-after-build.sh
+++ b/command-work/init/run-after-build.sh
@@ -79,28 +79,28 @@ function insertRunAfterBuildToRunBeforeBuild {
 }
 
 function runAfterBuildDo {
-    local length_of_array
     local in_the_end_array
     local command
+    local items_array
 
     if [[ "$is_to_run_in_the_end" == "false" ]]; then
         exit 0
     fi
 
-    in_the_end_array=$(echo "$run_before_build" | jq -r '.inTheEnd')
+    in_the_end_array=$(echo "$run_before_build" | jq -r ".inTheEnd")
     [ $? -ne 0 ] && throwError 1 "$in_the_end_array"
 
     if [[ "$in_the_end_array" == "null" ]]; then
         exit 0
     fi
 
-    length_of_array=$(echo "$in_the_end_array" | jq -r '. | length')
-    [ $? -ne 0 ] && throwError 1 "$length_of_array"
-    
-    for (( i=0; i<$length_of_array; i++ )); do
-        command=$(echo "$in_the_end_array" | jq -r ".[$i]")
-        [ $? -ne 0 ] && throwError 1 "$command"
+    items_array=()
+    while IFS= read -r line; do
+        items_array+=("$line")
+    done < <(echo "$in_the_end_array" | jq -c -r ".[]")
+    [ $? -ne 0 ] && throwError 1 "Error parsing in_the_end_array"
 
+    for command in "${items_array[@]}"; do
         echo "COMMAND: $command"
         (eval "$command")
         [ $? -ne 0 ] && throwError 156

--- a/command-work/remove/clean.sh
+++ b/command-work/remove/clean.sh
@@ -10,6 +10,7 @@ function clean {
     local clean_array
     local length
     local command
+    local items_array
 
     file_to_source="$config_dir/find-wrap.sh"
     source "$file_to_source"
@@ -42,8 +43,7 @@ function clean {
 
     echo "Cleaning wrap \"$wrap_name\""
 
-    local items_array
-    eval "items_array=($(echo "$clean_array" | jq -r '.[] | @sh'))"
+    eval "items_array=($(echo "$clean_array" | jq -e -r '.[] | @sh'))"
     [ $? -ne 0 ] && throwError 120 "Error getting commands"
 
     for command in "${items_array[@]}"; do

--- a/command-work/remove/clean.sh
+++ b/command-work/remove/clean.sh
@@ -9,7 +9,6 @@ function clean {
     local wrap
     local clean_array
     local length
-    local i
     local command
 
     file_to_source="$config_dir/find-wrap.sh"
@@ -43,8 +42,11 @@ function clean {
 
     echo "Cleaning wrap \"$wrap_name\""
 
-    for (( i=0; i<length; i++ )); do
-        command=$(echo "$clean_array" | jq -r ".[$i]")
+    local items_array
+    eval "items_array=($(echo "$clean_array" | jq -r '.[] | @sh'))"
+    [ $? -ne 0 ] && throwError 120 "Error getting commands"
+
+    for command in "${items_array[@]}"; do
         echo "CLEAN commnand: $command"
         (eval "$command")
         [ $? -ne 0 ] && throwError 121 "$command"

--- a/command-work/stop-kill/main.sh
+++ b/command-work/stop-kill/main.sh
@@ -175,14 +175,14 @@ function getDataForKill {
     [ $? -ne 0 ] && throwError 137 "$kill_signal"
 
     if [[ -n "$kill_signal" ]]; then
-        kill_options=$(echo "$kill_options" | jq -r ". + [ \"--signal \\\"$kill_signal\\\"\"] ")
+        kill_options=$(jq -c -r --argjson arr "$kill_options" --arg val "--signal \"$kill_signal\"" "$arr + [$val]" <<<"{}")
         [ $? -ne 0 ] && throwError 1 "Error within jq adding stop-signal"
     fi
 
     kill_options=$(getOptions "$current_dir" "$config_dir" "$common_utils_dir" "$file_with_config" "$wrap_name" "$kill_options" "kill-options")
     [ $? -ne 0 ] && throwError 128 "$kill_options (kill-options)"
 
-    kill_options_string=$(echo "$kill_options" | jq -r 'join(" ")')
+    kill_options_string=$(echo "$kill_options" | jq -r "join(\" \")")
     [ $? -ne 0 ] && throwError 1 "Error within jq joining kill-options"
 
     echo "$kill_options_string"

--- a/config-file-work/extract-start-data/main.sh
+++ b/config-file-work/extract-start-data/main.sh
@@ -285,14 +285,14 @@ function convertVolumesToOptions {
 function convertEntrypointValuesToOptions {
     local entrypoint_args_string
 
-    local length_array
     local entrypoint_commands_string=""
     local entrypoint_command
     local command_value
     local command_continue_in_error
 
     local cmd
-    local i
+    local items_array
+    local is_first="true"
 
     entrypoint_args_string=$(echo "$entrypoint_args" | jq -r 'join(" ")')
     if [ $? -ne 0 ]; then
@@ -300,19 +300,13 @@ function convertEntrypointValuesToOptions {
         exit 1
     fi
 
-    length_array=$(echo "$entrypoint_commands" | jq -r ". | length")
+    eval "items_array=($(echo "$entrypoint_commands" | jq -e -c -r '.[] | tostring | @sh'))"
     if [ $? -ne 0 ]; then
-        echo "Error within jq getting length of entrypoint_commands" >&2
+        echo "Error parsing entrypoint_commands array" >&2
         exit 1
     fi
 
-    for (( i=0; i<length_array; i++ )); do
-        entrypoint_command=$(echo "$entrypoint_commands" | jq -r ".[$i]")   
-        if [ $? -ne 0 ]; then
-            echo "Error within jq getting entrypoint_command" >&2
-            exit 1
-        fi
-
+    for entrypoint_command in "${items_array[@]}"; do
         command_value=$(echo "$entrypoint_command" | jq -r ".value")
         if [ $? -ne 0 ]; then
             echo "Error within jq getting value of entrypoint_command" >&2
@@ -325,8 +319,9 @@ function convertEntrypointValuesToOptions {
             exit 1
         fi
 
-        if [[ "$i" -eq 0 ]]; then
+        if [[ "$is_first" == "true" ]]; then
             entrypoint_commands_string="$command_value"
+            is_first="false"
         else
             entrypoint_commands_string="$entrypoint_commands_string $command_value"
         fi
@@ -339,7 +334,7 @@ function convertEntrypointValuesToOptions {
         fi
     done
 
-    if [[ "$length_array" -gt 0 ]]; then
+    if [[ ${#items_array[@]} -gt 0 ]]; then
         entrypoint_commands_string="$entrypoint_commands_string exit 0"
     fi
 
@@ -347,7 +342,7 @@ function convertEntrypointValuesToOptions {
     if [[ ${#cmd} -gt 0 && ${#entrypoint_commands_string} -gt 0 ]]; then
         cmd="$cmd \"${entrypoint_commands_string//\"/\\\"}\""
     elif [[ ${#entrypoint_commands_string} -gt 0 ]]; then
-        cmd=cmd="\"${entrypoint_commands_string//\"/\\\"}\""
+        cmd="\"${entrypoint_commands_string//\"/\\\"}\""
     fi
 
     echo "$cmd"


### PR DESCRIPTION
Performance issues inside bash loops caused by spawning multiple `jq` processes inside `for` loops have been resolved.

Instead of calling `jq -r ".[$i]"` within a loop, arrays are extracted in a single go into a bash array format using `eval "array=($(echo "$json" | jq -e -r '.[] | @sh'))"`. Furthermore, modifying arrays inside loop structures has been optimized to construct values inside bash and either accumulate using strings, or using fewer outer scoped `jq` calls to update the objects.

Tested to preserve exiting on first error using existing `throwError` semantics.

---
*PR created automatically by Jules for task [15549863890667810035](https://jules.google.com/task/15549863890667810035) started by @RomaTk*